### PR TITLE
Improve docs with example loading/error state

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,61 @@ In Storybook, click "Show Addons" and navigate to the "Apollo Client" tab.
 To see real world usage of how to use this addon, check out the example app:
 
 https://github.com/lifeiscontent/realworld
+
+## Loading State
+
+You can use the `delay` parameter to simulate loading state.
+
+```
+import DashboardPage, { DashboardPageQuery } from '.';
+
+export default {
+  title: 'My Story',
+};
+
+export const Example = () => <DashboardPage />;
+
+Example.parameters = {
+  apolloClient: {
+    mocks: [
+      {
+        // Use `delay` parameter to increase loading time
+        delay: 1e21,
+        request: {
+          query: DashboardPageQuery,
+        },
+        result: {
+          data: {},
+        },
+      },
+    ],
+  },
+};
+```
+
+## Error State
+
+You can use the `error` parameter to create error state.
+
+```
+import DashboardPage, { DashboardPageQuery } from '.';
+
+export default {
+  title: 'My Story',
+};
+
+export const Example = () => <DashboardPage />;
+
+Example.parameters = {
+  apolloClient: {
+    mocks: [
+      {
+        request: {
+          query: DashboardPageQuery,
+        },
+        error: new Error('This is a mock network error'),
+      },
+    ],
+  },
+};
+```


### PR DESCRIPTION
This was mentioned in issue https://github.com/lifeiscontent/storybook-addon-apollo-client/issues/37 and thought it may be worth a quick PR.  I know that I came back to the `addon` to see how to do `loading` state and that is when I checked the issues and seen someone else had felt the same way.  

I can understand not wanting to have to follow `MockedProvider` as a dupe source of info...so perhaps if we don't want to maintain this type of information we just provide links to relevant docs?