### PR TITLE
chore: Add tslib to the dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "prettier": "2.3.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "tslib": "2.3.0",
     "typescript": "4.3.5"
   },
   "dependencies": {
     "@storybook/addons": "^6",
     "@storybook/api": "^6",
-    "@storybook/components": "^6"
+    "@storybook/components": "^6",
+    "tslib": "2.3.0"
   },
   "optionalDependencies": {
     "@apollo/client": ">=2.0.0",


### PR DESCRIPTION
`tslib` is used at runtime, rather than just at build time. This means
that the `tslib` dependency (and version) should be statically declared
for consistent behavior.

Fixes #63