### PR TITLE
mocks as a readonly array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { DocumentNode } from "graphql";
 export interface MockedProviderProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
-  mocks?: MockedResponse[];
+  mocks?: ReadonlyArray<MockedResponse>;
   children?: React.ReactNode;
 }
 


### PR DESCRIPTION
In `MockedProvider` in `@apollo/client/testing`, the array is readonly which creates an error when matching the types.

![image](https://user-images.githubusercontent.com/2819256/154142246-8d2acad1-846c-4ea0-bd87-e4bc12294ff9.png)

![image](https://user-images.githubusercontent.com/2819256/154142267-d0e7ddf7-5a6c-4f20-be6c-0b031585c1be.png)

This is a quick bug fix; the true solution involves using `MockedProvider` types from `@apollo/client/testing` directly. The intended use case of this package is to drop in `MockedProvider`, so the types should be one-to-one.