### PR TITLE
chore: add variable matcher example

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -9,7 +9,7 @@ import { Addon_RenderOptions } from "storybook/internal/types";
 
 import { PanelContent } from "./components/PanelContent";
 import { ADDON_ID, EVENTS } from "./constants";
-import { ApolloAddonState } from "./types";
+import { ApolloClientAddonState } from "./types";
 
 const getMockName = (mockedResponse: MockedResponse): string => {
   if (mockedResponse.request.operationName) {
@@ -32,13 +32,13 @@ export const Panel: React.FC<Partial<Addon_RenderOptions>> = ({
   active = false,
 }) => {
   const [activeMockIndex, setActiveMockIndex] = React.useState(-1);
-  const [state, setState] = useAddonState<ApolloAddonState>(ADDON_ID, {
+  const [state, setState] = useAddonState<ApolloClientAddonState>(ADDON_ID, {
     mocks: [],
     queries: [],
   });
 
   const emit = useChannel({
-    [EVENTS.RESULT]: (apolloAddonState: ApolloAddonState) => {
+    [EVENTS.RESULT]: (apolloAddonState: ApolloClientAddonState) => {
       setState(apolloAddonState);
       setActiveMockIndex((prev) => {
         if (prev === -1) {
@@ -70,25 +70,25 @@ export const Panel: React.FC<Partial<Addon_RenderOptions>> = ({
   return (
     <AddonPanel active={active}>
       <>
-      <Form.Field label="Mock">
-        <Form.Select
-          size="flex"
-          value={activeMockIndex}
-          disabled={!state.mocks.length}
-          onChange={(event) => {
-            const { value } = event.currentTarget;
-            setActiveMockIndex(Number(value));
-          }}
-        >
-          <option value="">Select a mock</option>
-          {state.mocks.map((mockedResponse, index) => (
-            <option key={index} value={index}>
-              {getMockName(mockedResponse)}
-            </option>
-          ))}
-        </Form.Select>
-      </Form.Field>
-      <PanelContent mock={activeMock} query={activeQuery} />
+        <Form.Field label="Mock">
+          <Form.Select
+            size="flex"
+            value={activeMockIndex}
+            disabled={!state.mocks.length}
+            onChange={(event) => {
+              const { value } = event.currentTarget;
+              setActiveMockIndex(Number(value));
+            }}
+          >
+            <option value="">Select a mock</option>
+            {state.mocks.map((mockedResponse, index) => (
+              <option key={index} value={index}>
+                {getMockName(mockedResponse)}
+              </option>
+            ))}
+          </Form.Select>
+        </Form.Field>
+        <PanelContent mock={activeMock} query={activeQuery} />
       </>
     </AddonPanel>
   );

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -2,10 +2,10 @@ import { addons, types } from "storybook/internal/manager-api";
 import { ADDON_ID, PANEL_ID } from "./constants";
 import { Panel } from "./Panel";
 import { Title } from "./Title";
-import { ApolloParameters } from "./types";
+import { ApolloClientParameters } from "./types";
 
 declare module "@storybook/react" {
-  interface Parameters extends ApolloParameters {}
+  interface Parameters extends ApolloClientParameters {}
 }
 
 /**

--- a/src/stories/DisplayLocation.stories.ts
+++ b/src/stories/DisplayLocation.stories.ts
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { DisplayLocation, GET_LOCATION_QUERY } from "./DisplayLocation";
 import { ApolloError } from "@apollo/client";
+import { expect, fn, within } from "@storybook/test";
+import { MockedResponse } from "@apollo/client/testing";
 
 const meta: Meta<typeof DisplayLocation> = {
   title: "Example/DisplayLocation",
@@ -87,5 +89,48 @@ export const WithError: Story = {
         },
       ],
     },
+  },
+};
+
+export const WithVariableMatcher: Story = {
+  parameters: {
+    apolloClient: {
+      mocks: [
+        {
+          request: {
+            query: GET_LOCATION_QUERY,
+          },
+          variableMatcher: fn(() => true),
+          result: {
+            data: {
+              location: {
+                id: 1,
+                name: "Location 1",
+                description: "This is a location",
+                photo: "https://placehold.co/400x250",
+                __typename: "Location",
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+  play: async ({ parameters, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const mock = parameters.apolloClient!.mocks![0]!;
+    await expect(
+      // @ts-expect-error - storybook types are wrong
+      canvas.getByRole("heading", { name: mock.result.data.location.name }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("img", { name: "location-reference" }),
+      // @ts-expect-error - storybook types are wrong
+    ).toHaveAttribute("src", mock.result.data.location.photo);
+    await expect(
+      // @ts-expect-error - storybook types are wrong
+      canvas.getByText(mock.result.data.location.description),
+    ).toBeInTheDocument();
+    await expect(mock.variableMatcher).toHaveBeenCalledWith({ locationId: 1 });
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,11 @@ import type {
   MockedProviderProps,
 } from "@apollo/client/testing";
 
-export type ApolloAddonState = {
+export type ApolloClientAddonState = {
   mocks: MockedResponse[];
   queries: string[];
 };
 
-export type ApolloParameters = {
+export type ApolloClientParameters = {
   apolloClient?: Partial<Omit<MockedProviderProps, "children">>;
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.1--canary.129.7ac3395.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-apollo-client@8.1.1--canary.129.7ac3395.0
  # or 
  yarn add storybook-addon-apollo-client@8.1.1--canary.129.7ac3395.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
