### PR TITLE
feat: upgrade to Apollo Client v4

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,11 +1,15 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: ["@storybook/addon-links", "./local-preset.js", "@storybook/addon-docs"],
+  addons: [
+    "@storybook/addon-links",
+    "./local-preset.js",
+    "@storybook/addon-docs",
+  ],
 
   framework: {
     name: "@storybook/react-vite",
     options: {},
-  }
+  },
 };
 export default config;

--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ Example.parameters = {
 };
 ```
 
-## Error State
+## Error States
 
-You can use the `error` parameter to create error state.
+Based on [Apollo Client's Testing Error States](https://www.apollographql.com/docs/react/development-testing/testing#testing-error-states) you can simulate both network errors and GraphQL errors.
+
+### Network Errors
 
 ```js
 import DashboardPage, { DashboardPageQuery } from ".";
@@ -214,6 +216,32 @@ Example.parameters = {
           query: DashboardPageQuery,
         },
         error: new Error("This is a mock network error"),
+      },
+    ],
+  },
+};
+```
+
+### GraphQL errors
+
+```js
+import DashboardPage, { DashboardPageQuery } from ".";
+import { GraphQLError } from 'graphql'
+
+export default {
+  title: "My Story",
+};
+
+export const Example = () => <DashboardPage />;
+
+Example.parameters = {
+  apolloClient: {
+    mocks: [
+      {
+        // ...
+        result: {
+          errors: [new GraphQLError("Error!")],
+        },
       },
     ],
   },

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ export default {
 **preview.ts**
 
 ```js
-import { MockedProvider } from "@apollo/client/testing"; // Use for Apollo Version 3+
+import { MockedProvider } from "@apollo/client/testing/react"; // Use for Apollo Version 4+
+// import { MockedProvider } from "@apollo/client/testing"; // Use for Apollo Version 3+
 // import { MockedProvider } from "@apollo/react-testing"; // Use for Apollo Version < 3
 
 export const preview = {
@@ -212,7 +213,7 @@ Example.parameters = {
         request: {
           query: DashboardPageQuery,
         },
-        error: new ApolloError("This is a mock network error"),
+        error: new Error("This is a mock network error"),
       },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "9.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@apollo/client": "^4.0.5",
-        "@storybook/addon-docs": "9.0.12",
-        "@storybook/addon-links": "9.0.12",
-        "@storybook/react-vite": "9.0.12",
+        "@apollo/client": "^4.0.7",
+        "@storybook/addon-docs": "^9.1.15",
+        "@storybook/addon-links": "^9.1.15",
+        "@storybook/react-vite": "^9.1.15",
         "@types/node": "22.13.4",
         "@types/react": "19.1.8",
         "@types/react-dom": "19.1.6",
@@ -28,7 +28,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "rollup": "4.44.0",
-        "storybook": "9.0.12",
+        "storybook": "^9.1.15",
         "tsup": "^8.5.0",
         "typescript": "5.8.3",
         "vite": "6.3.5",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.5.tgz",
-      "integrity": "sha512-H0FQXa6MRWQS0/jNv4VO6NfUWueZ4L7QYjkbSztADpugb4yTzRBVVwFq5mL3FJVJWewxWVrzJof/yzCTVTsXaw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.7.tgz",
+      "integrity": "sha512-hZp/mKtAqM+g6buUnu6Wqtyc33QebvfdY0SE46xWea4lU1CxwI57VORy2N2vA9CoCRgYM4ELNXzr6nNErAdhfg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -352,6 +352,7 @@
       "version": "7.27.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -543,7 +544,6 @@
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -741,7 +741,9 @@
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
-      "version": "0.6.0",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.6.1.tgz",
+      "integrity": "sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -751,7 +753,7 @@
       },
       "peerDependencies": {
         "typescript": ">= 4.3.x",
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -862,6 +864,7 @@
       "version": "3.6.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -1318,16 +1321,16 @@
       ]
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.0.12.tgz",
-      "integrity": "sha512-bAuFy4BWGEBIC0EAS4N+V8mHj7NZiSdDnJUSr4Al3znEVzNHLpQAMRznkga2Ok8x+gwcyBG7W47dLbDXVqLZDg==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.15.tgz",
+      "integrity": "sha512-thbBQKzN0ycSEQjtIeXJT4i6+4kWoNIWYo4x2GQ3jtqHsT8T4FZW1n/xK1ysZbB4eCwG2hOn44BRTu8p4S7UoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.0.12",
-        "@storybook/icons": "^1.2.12",
-        "@storybook/react-dom-shim": "9.0.12",
+        "@storybook/csf-plugin": "9.1.15",
+        "@storybook/icons": "^1.4.0",
+        "@storybook/react-dom-shim": "9.1.15",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -1337,13 +1340,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.0.12"
+        "storybook": "^9.1.15"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.0.12.tgz",
-      "integrity": "sha512-Ix7WXnCMkEWrgBrGCoZAFH276Xj/4g8e5Kao9BSZneUBjJJC2LuCaTftGeiM4kQ7sKBPOc/L6zIyusWckBvXIQ==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.15.tgz",
+      "integrity": "sha512-pPrE2rbLzZewsvEN5pbJ4xfc05RADP7MMkaqySNWwcNQwLx0GLvk3ZL+bA/wG73aaPH+w3Gc7gy2En8q5m+DBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1355,7 +1358,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.0.12"
+        "storybook": "^9.1.15"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -1364,13 +1367,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.0.12.tgz",
-      "integrity": "sha512-Jh6CJKHJQ+N1BiPr6fY91EMV5X0xBuIAhLpaNSKrshkdnXd/fBbRgE8iPJdnr+SCqaFErBjAjBzKkotwKU138A==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.15.tgz",
+      "integrity": "sha512-GZkx72cBnCuTL/cVOIWIicB4GCmZWx52zFGSC/qHOT/sKcUkrIoQSpVljqyPa66woHyUeSZX4mu7aGj5A27QVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.0.12",
+        "@storybook/csf-plugin": "9.1.15",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -1378,14 +1381,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.0.12",
-        "vite": "^5.0.0 || ^6.0.0"
+        "storybook": "^9.1.15",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.0.12.tgz",
-      "integrity": "sha512-5EueJQJAu77Lh+EedG4Q/kEOZNlTY/g+fWsT7B5DTtLVy0ypnghsHY8X3KYT/0+NNgTtoO0if4F+ejVYaLnMzA==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.15.tgz",
+      "integrity": "sha512-UThWh7V3+zd+71XdIsNFkrNslkjyaD/HQPnjWGWBCU4ZWNWRSPd3r0r02nH0zzo+NBi0V4vzNDg/PmfD51iaOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1396,7 +1399,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.0.12"
+        "storybook": "^9.1.15"
       }
     },
     "node_modules/@storybook/global": {
@@ -1417,14 +1420,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.0.12.tgz",
-      "integrity": "sha512-rDrf5MDfsguNDTSOfGqhAjQDhp3jDMdzAoCqLjQ75M647C8nsv9i+fftO3k0rMxIJRrESpZWqVZ4tsjOX+J3DA==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.15.tgz",
+      "integrity": "sha512-tdd1Od3roaEQ2rjqk1L15yR/N2y/SLNcpPNp3n9AQT1eDPdbKzIzue7u1eW9KUFdwSF9S8xG35roDUkKwBJogQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.0.12"
+        "@storybook/react-dom-shim": "9.1.15"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1436,7 +1439,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.0.12",
+        "storybook": "^9.1.15",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -1446,9 +1449,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.0.12.tgz",
-      "integrity": "sha512-OMBitzkJRga/UJF1ScSnaxgBSlAVePCK8wzPkGDn0MmsjZ4oDWuNZeKnVO1+tb6n2rZHws7RmKGxHzHAZTY+zQ==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.15.tgz",
+      "integrity": "sha512-l6smvNwxh6kp2U/BupzQ4/NSraTWysZcAe2x+GO5CiIIB8Jbi41XLu5XIHI/GQRnNqpXXE3uMImiHGOORmHEXA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1458,20 +1461,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.0.12"
+        "storybook": "^9.1.15"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.0.12.tgz",
-      "integrity": "sha512-TAXkBBiy2dYGL8rXiqAZh1A9w83R9SFa9EiGDYIek+fSKRnbMAclO8cxtDUOuwKzVQ0mzvL2DPtHV6uaoec/Eg==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-9.1.15.tgz",
+      "integrity": "sha512-ORD3swzehAx6o7Sw/wmXr/L5Q4FANPsc1+G5s6OTfmbWNDy/e803h7lsUUFwokh7PeYgylJzbPMQ8HnkNghN0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.0",
+        "@joshwooding/vite-plugin-react-docgen-typescript": "0.6.1",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "9.0.12",
-        "@storybook/react": "9.0.12",
+        "@storybook/builder-vite": "9.1.15",
+        "@storybook/react": "9.1.15",
         "find-up": "^7.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -1488,8 +1491,8 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.0.12",
-        "vite": "^5.0.0 || ^6.0.0"
+        "storybook": "^9.1.15",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -1498,7 +1501,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1519,7 +1521,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1549,8 +1550,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1589,6 +1589,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/command-line-args": {
       "version": "5.2.3",
       "dev": true,
@@ -1596,6 +1607,13 @@
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1618,6 +1636,7 @@
       "version": "22.13.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1633,6 +1652,7 @@
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1671,6 +1691,101 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@wry/caches": {
@@ -1885,6 +2000,8 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2081,6 +2198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -2160,7 +2278,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "5.2.0",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2171,7 +2291,7 @@
         "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2191,6 +2311,8 @@
     },
     "node_modules/check-error": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2467,6 +2589,7 @@
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -2547,6 +2670,8 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2588,7 +2713,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2639,8 +2763,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "8.6.0",
@@ -2725,6 +2848,7 @@
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2979,7 +3103,8 @@
     "node_modules/fp-ts": {
       "version": "2.16.10",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
@@ -3179,6 +3304,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3626,7 +3752,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.4",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3644,7 +3772,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4155,7 +4282,9 @@
       "license": "MIT"
     },
     "node_modules/pathval": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4300,6 +4429,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4315,6 +4445,7 @@
       "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4331,7 +4462,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4347,7 +4477,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4360,8 +4489,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -4435,6 +4563,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4461,6 +4590,8 @@
     },
     "node_modules/react-docgen-typescript": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4485,6 +4616,7 @@
       "version": "19.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4650,6 +4782,7 @@
       "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4860,17 +4993,19 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.0.12.tgz",
-      "integrity": "sha512-mpACe6BMd/M5sqcOiA8NmWIm2zdx0t4ujnA4NTcq4aErdK/KKuU255UM4pO3DIf5zWR5VrDfNV5UaMi/VgE2mA==",
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.15.tgz",
+      "integrity": "sha512-es7uDdEwRVVUAt7XLAZZ1hicOq9r4ov5NFeFPpa2YEyAsyHYOCr0CTlHBfslWG6D5EVNWK3kVIIuW8GHB6hEig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",
-        "@vitest/expect": "3.0.9",
-        "@vitest/spy": "3.0.9",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/spy": "3.2.4",
         "better-opn": "^3.0.2",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
         "esbuild-register": "^3.5.0",
@@ -4925,55 +5060,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/storybook/node_modules/@vitest/expect": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.0.9",
-        "@vitest/utils": "3.0.9",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/storybook/node_modules/@vitest/pretty-format": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/storybook/node_modules/@vitest/spy": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^3.0.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/storybook/node_modules/@vitest/utils": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.0.9",
-        "loupe": "^3.1.3",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/storybook/node_modules/chalk": {
       "version": "3.0.0",
       "dev": true,
@@ -5000,14 +5086,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/storybook/node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/string-width": {
@@ -5279,8 +5357,20 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5484,6 +5574,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5597,6 +5688,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@apollo/client": "^3.13.8",
+        "@apollo/client": "^4.0.5",
         "@storybook/addon-docs": "9.0.12",
         "@storybook/addon-links": "9.0.12",
         "@storybook/react-vite": "9.0.12",
@@ -35,7 +35,7 @@
         "zx": "8.6.0"
       },
       "peerDependencies": {
-        "@apollo/client": "^3.0.0",
+        "@apollo/client": "^3.0.0 || ^4.0.0",
         "graphql": "^16.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -58,30 +58,31 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.13.8",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.8.tgz",
-      "integrity": "sha512-YM9lQpm0VfVco4DSyKooHS/fDTiKQcCHfxr7i3iL6a0kP/jNO5+4NFK6vtRDxaYisd5BrwOZHLJpPBnvRVpKPg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.5.tgz",
+      "integrity": "sha512-H0FQXa6MRWQS0/jNv4VO6NfUWueZ4L7QYjkbSztADpugb4yTzRBVVwFq5mL3FJVJWewxWVrzJof/yzCTVTsXaw==",
       "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "dist",
+        "codegen",
+        "scripts/codemods/ac3-to-ac4"
+      ],
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
         "@wry/equality": "^0.5.6",
         "@wry/trie": "^0.5.0",
         "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.18.0",
-        "prop-types": "^15.7.2",
-        "rehackt": "^0.1.0",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql": "^16.0.0",
         "graphql-ws": "^5.5.5 || ^6.0.3",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -3216,15 +3217,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "dev": true,
@@ -3631,18 +3623,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -4409,17 +4389,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -4523,12 +4492,6 @@
         "react": "^19.1.0"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4626,24 +4589,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rehackt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
-      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
-      "dev": true,
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/remove-markdown": {
@@ -4759,6 +4704,17 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/scheduler": {
@@ -5221,15 +5177,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/table-layout": {
       "version": "1.0.2",
       "dev": true,
@@ -5376,18 +5323,6 @@
       "version": "0.1.13",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
@@ -5895,21 +5830,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "dev": true,
-      "dependencies": {
-        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zx": {

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "build-storybook": "storybook build"
   },
   "devDependencies": {
-    "@apollo/client": "^4.0.5",
-    "@storybook/addon-docs": "9.0.12",
-    "@storybook/addon-links": "9.0.12",
-    "@storybook/react-vite": "9.0.12",
+    "@apollo/client": "^4.0.7",
+    "@storybook/addon-docs": "^9.1.15",
+    "@storybook/addon-links": "^9.1.15",
+    "@storybook/react-vite": "^9.1.15",
     "@types/node": "22.13.4",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
@@ -68,7 +68,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "rollup": "4.44.0",
-    "storybook": "9.0.12",
+    "storybook": "^9.1.15",
     "tsup": "^8.5.0",
     "typescript": "5.8.3",
     "vite": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build-storybook": "storybook build"
   },
   "devDependencies": {
-    "@apollo/client": "^3.13.8",
+    "@apollo/client": "^4.0.5",
     "@storybook/addon-docs": "9.0.12",
     "@storybook/addon-links": "9.0.12",
     "@storybook/react-vite": "9.0.12",
@@ -75,7 +75,7 @@
     "zx": "8.6.0"
   },
   "peerDependencies": {
-    "@apollo/client": "^3.0.0",
+    "@apollo/client": "^3.0.0 || ^4.0.0",
     "graphql": "^16.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { MockedResponse } from "@apollo/client/testing";
 import type { OperationDefinitionNode } from "graphql";
 
 import { AddonPanel, Form } from "storybook/internal/components";
@@ -9,9 +8,9 @@ import { Addon_RenderOptions } from "storybook/internal/types";
 
 import { PanelContent } from "./components/PanelContent";
 import { ADDON_ID, EVENTS } from "./constants";
-import { ApolloClientAddonState } from "./types";
+import { ApolloClientAddonState, ExtendedMockedResponse } from "./types";
 
-const getMockName = (mockedResponse: MockedResponse): string => {
+const getMockName = (mockedResponse: ExtendedMockedResponse): string => {
   if (mockedResponse.request.operationName) {
     return mockedResponse.request.operationName;
   }

--- a/src/components/PanelContent.tsx
+++ b/src/components/PanelContent.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-import type { MockedResponse } from "@apollo/client/testing";
 import {
   Placeholder,
   SyntaxHighlighter,
   TabsState,
 } from "storybook/internal/components";
 import { convert, themes } from "storybook/internal/theming";
+import { ExtendedMockedResponse } from "../types";
 
 interface PanelContentProps {
-  mock?: MockedResponse;
+  mock?: ExtendedMockedResponse;
   query?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import { ApolloClientParameters } from './types';
+import { ApolloClientParameters } from "./types";
 
-export { PARAM_KEY } from './constants';
-export * from './preview';
+export { PARAM_KEY } from "./constants";
+export * from "./preview";
 
-declare module 'storybook/internal/csf' {
+declare module "storybook/internal/csf" {
   interface Parameters {
     apolloClient?: ApolloClientParameters;
   }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,3 +1,4 @@
+import { type DecoratorFunction } from "storybook/internal/csf";
 import { withApolloClient } from "./withApolloClient";
 
-export const decorators = [withApolloClient];
+export const decorators: DecoratorFunction[] = [withApolloClient];

--- a/src/stories/DisplayLocation.stories.ts
+++ b/src/stories/DisplayLocation.stories.ts
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { DisplayLocation, GET_LOCATION_QUERY } from "./DisplayLocation";
-import { ApolloError } from "@apollo/client";
+import { GraphQLError } from "graphql";
 import { expect, fn, within } from "storybook/test";
-import { MockedResponse } from "@apollo/client/testing";
 
 const meta: Meta<typeof DisplayLocation> = {
   title: "Example/DisplayLocation",
@@ -85,7 +84,7 @@ export const WithError: Story = {
               locationId: 1,
             },
           },
-          error: new ApolloError({ errorMessage: "Could not get location" }),
+          error: new GraphQLError("Could not get location"),
         },
       ],
     },

--- a/src/stories/DisplayLocation.stories.ts
+++ b/src/stories/DisplayLocation.stories.ts
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { DisplayLocation, GET_LOCATION_QUERY } from "./DisplayLocation";
-import { GraphQLError } from "graphql";
 import { expect, fn, within } from "storybook/test";
 
 const meta: Meta<typeof DisplayLocation> = {
@@ -84,22 +83,22 @@ export const WithError: Story = {
               locationId: 1,
             },
           },
-          error: new GraphQLError("Could not get location"),
+          error: new Error("Could not get location"),
         },
       ],
     },
   },
 };
 
-export const WithVariableMatcher: Story = {
+export const WithDynamicVariable: Story = {
   parameters: {
     apolloClient: {
       mocks: [
         {
           request: {
             query: GET_LOCATION_QUERY,
+            variables: fn(() => true),
           },
-          variableMatcher: fn(() => true),
           result: {
             data: {
               location: {
@@ -130,6 +129,8 @@ export const WithVariableMatcher: Story = {
       // @ts-expect-error - storybook types are wrong
       canvas.getByText(mock.result.data.location.description),
     ).toBeInTheDocument();
-    await expect(mock.variableMatcher).toHaveBeenCalledWith({ locationId: 1 });
+    await expect(mock.request.variables).toHaveBeenCalledWith(
+      expect.objectContaining({ locationId: 1 }),
+    );
   },
 };

--- a/src/stories/DisplayLocation.tsx
+++ b/src/stories/DisplayLocation.tsx
@@ -1,7 +1,23 @@
 import React from "react";
-import { useQuery, gql } from "@apollo/client";
+import { gql, type TypedDocumentNode } from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
 
-export const GET_LOCATION_QUERY = gql`
+type LocationsQuery = {
+  location: {
+    id: string;
+    name: string;
+    description: string;
+    photo: string;
+  };
+};
+type LocationQueryVariables = {
+  locationId: number;
+};
+
+export const GET_LOCATION_QUERY: TypedDocumentNode<
+  LocationsQuery,
+  LocationQueryVariables
+> = gql`
   query GetLocation($locationId: Int!) {
     location(id: $locationId) {
       id

--- a/src/stories/DisplayLocations.stories.ts
+++ b/src/stories/DisplayLocations.stories.ts
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { DisplayLocations, GET_LOCATIONS_QUERY } from "./DisplayLocations";
 import { GET_LOCATION_QUERY } from "./DisplayLocation";
-import { GraphQLError } from "graphql";
 
 const meta: Meta<typeof DisplayLocations> = {
   title: "Example/DisplayLocations",
@@ -115,7 +114,7 @@ export const WithError: Story = {
           request: {
             query: GET_LOCATIONS_QUERY,
           },
-          error: new GraphQLError("Could not get locations"),
+          error: new Error("Could not get locations"),
         },
       ],
     },

--- a/src/stories/DisplayLocations.stories.ts
+++ b/src/stories/DisplayLocations.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { DisplayLocations, GET_LOCATIONS_QUERY } from "./DisplayLocations";
 import { GET_LOCATION_QUERY } from "./DisplayLocation";
-import { ApolloError } from "@apollo/client";
+import { GraphQLError } from "graphql";
 
 const meta: Meta<typeof DisplayLocations> = {
   title: "Example/DisplayLocations",
@@ -115,7 +115,7 @@ export const WithError: Story = {
           request: {
             query: GET_LOCATIONS_QUERY,
           },
-          error: new ApolloError({ errorMessage: "Could not get locations" }),
+          error: new GraphQLError("Could not get locations"),
         },
       ],
     },

--- a/src/stories/DisplayLocations.tsx
+++ b/src/stories/DisplayLocations.tsx
@@ -1,7 +1,17 @@
 import React from "react";
-import { useQuery, gql } from "@apollo/client";
+import { gql, type TypedDocumentNode } from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
 
-export const GET_LOCATIONS_QUERY = gql`
+type LocationsQuery = {
+  locations: Array<{
+    id: string;
+    name: string;
+    description: string;
+    photo: string;
+  }>;
+};
+
+export const GET_LOCATIONS_QUERY: TypedDocumentNode<LocationsQuery> = gql`
   query GetLocations {
     locations {
       id
@@ -18,7 +28,7 @@ export function DisplayLocations() {
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error : {error.message}</p>;
 
-  return data.locations.map(({ id, name, description, photo }: any) => (
+  return data?.locations.map(({ id, name, description, photo }: any) => (
     <div key={id}>
       <h3>{name}</h3>
       <img width="400" height="250" alt="location-reference" src={`${photo}`} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,22 @@
-import { MockedProviderProps, MockedResponse } from "@apollo/client/testing";
+import { type MockLink } from "@apollo/client/testing";
+import { type MockedProviderProps } from "@apollo/client/testing/react";
+
+// Extended MockedRequest to include optional properties
+export interface ExtendedMockedRequest extends MockLink.MockedRequest {
+  operationName?: string;
+  extensions?: Record<string, any>;
+  context?: Record<string, any>;
+}
+
+// Extended MockedResponse to include variableMatcher
+export interface ExtendedMockedResponse
+  extends Omit<MockLink.MockedResponse, "request"> {
+  request: ExtendedMockedRequest;
+  variableMatcher?: (variables: any) => boolean;
+}
 
 export type ApolloClientAddonState = {
-  mocks: MockedResponse[];
+  mocks: ExtendedMockedResponse[];
   queries: string[];
 };
 
@@ -12,5 +27,7 @@ export interface ApolloClientTypes {
 }
 
 export type ApolloClientParameters = Partial<
-  Omit<MockedProviderProps, "children">
+  Omit<MockedProviderProps, "children" | "mocks"> & {
+    mocks?: ExtendedMockedResponse[];
+  }
 >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,6 @@ export interface ExtendedMockedRequest extends MockLink.MockedRequest {
 export interface ExtendedMockedResponse
   extends Omit<MockLink.MockedResponse, "request"> {
   request: ExtendedMockedRequest;
-  variableMatcher?: (variables: any) => boolean;
 }
 
 export type ApolloClientAddonState = {
@@ -27,7 +26,5 @@ export interface ApolloClientTypes {
 }
 
 export type ApolloClientParameters = Partial<
-  Omit<MockedProviderProps, "children" | "mocks"> & {
-    mocks?: ExtendedMockedResponse[];
-  }
+  Omit<MockedProviderProps, "children">
 >;

--- a/src/withApolloClient.tsx
+++ b/src/withApolloClient.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useChannel } from "storybook/internal/preview-api";
 import { EVENTS, PARAM_KEY } from "./constants";
 import { print } from "graphql";
-import { MockedProvider } from "@apollo/client/testing";
+import { MockedProvider } from "@apollo/client/testing/react";
 import type { DecoratorFunction } from "storybook/internal/types";
 
 export const withApolloClient: DecoratorFunction = (Story, context) => {


### PR DESCRIPTION
## Summary

This PR upgrades the storybook-addon-apollo-client to support Apollo Client v4, addressing compatibility issues with the latest version.

### Key Changes
- Updated `@apollo/client` from v3.13.8 to v4.0.5
- Fixed import paths for `MockedProvider` (now from `@apollo/client/testing/react`)
- Updated peer dependencies to support both v3 and v4 (`^3.0.0 || ^4.0.0`)
- Replaced `ApolloError` with `GraphQLError` in stories and documentation
- Updated import paths in components to use Apollo Client v4 structure
- Added proper TypeScript types for GraphQL queries

### Breaking Changes
- Import path for `MockedProvider` changed from `@apollo/client/testing` to `@apollo/client/testing/react`
- Some Apollo Client v3 specific imports may need updates

### Testing
- Updated story examples to use `GraphQLError` instead of `ApolloError`
- Verified components work with both hook-based and render prop patterns

Closes #135